### PR TITLE
Add definitions for direct boot and virtiofs

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -28,6 +28,17 @@ let
               (sub "path" typePath))
             (subelem "boot" [ (subattr "dev" typeString) ] [ ])
             (subelem "bootmenu" [ (subattr "enable" typeBoolYesNo) ] [ ])
+
+            (subelem "kernel" [ ] (sub "path" typeString))
+            (subelem "initrd" [ ] (sub "path" typeString))
+            (subelem "cmdline" [ ] (sub "options" typeString))
+
+          ]
+        )
+        (subelem "memoryBacking" [ ]
+          [
+            (subelem "source" [ (subattr "type" typeString) ] [ ])
+            (subelem "access" [ (subattr "mode" typeString) ] [ ])
           ]
         )
         (subelem "features" [ ]
@@ -148,6 +159,23 @@ let
                   )
                   (subelem "source" [ (subattr "file" typePath) (subattr "startupPolicy" typeString) ] [ ])
                   targetelem
+                  (subelem "readonly" [ ] [ ])
+                  addresselem
+                ]
+              )
+              (subelem "filesystem" [ (subattr "type" typeString) (subattr "accessmode" typeString) ]
+                [
+                  (subelem "driver"
+                    [
+                      (subattr "name" typeString)
+                      (subattr "type" typeString)
+                      (subattr "cache" typeString)
+                      (subattr "discard" typeString)
+                    ] [ ]
+                  )
+                  (subelem "binary" [ (subattr "path" typeString) ] [ ])
+                  (subelem "source" [ (subattr "dir" typeString) (subattr "name" typeString) ] [ ])
+                  (subelem "target" [ (subattr "dir" typeString) ] [ ])
                   (subelem "readonly" [ ] [ ])
                   addresselem
                 ]

--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -29,8 +29,8 @@ let
             (subelem "boot" [ (subattr "dev" typeString) ] [ ])
             (subelem "bootmenu" [ (subattr "enable" typeBoolYesNo) ] [ ])
 
-            (subelem "kernel" [ ] (sub "path" typeString))
-            (subelem "initrd" [ ] (sub "path" typeString))
+            (subelem "kernel" [ ] (sub "path" typePath))
+            (subelem "initrd" [ ] (sub "path" typePath))
             (subelem "cmdline" [ ] (sub "options" typeString))
 
           ]
@@ -173,9 +173,9 @@ let
                       (subattr "discard" typeString)
                     ] [ ]
                   )
-                  (subelem "binary" [ (subattr "path" typeString) ] [ ])
-                  (subelem "source" [ (subattr "dir" typeString) (subattr "name" typeString) ] [ ])
-                  (subelem "target" [ (subattr "dir" typeString) ] [ ])
+                  (subelem "binary" [ (subattr "path" typePath) ] [ ])
+                  (subelem "source" [ (subattr "dir" typePath) (subattr "name" typeString) ] [ ])
+                  (subelem "target" [ (subattr "dir" typePath) ] [ ])
                   (subelem "readonly" [ ] [ ])
                   addresselem
                 ]


### PR DESCRIPTION
I've added in options required to get direct boot and file sharing via virtiofs to the domain object.

Awesome project btw - I've wanted to incorporate declarative libvirt into my configs for ages.