### PR TITLE
Check for transient domains before unedefining deactivated objects

### DIFF
--- a/tool/nixvirt.py
+++ b/tool/nixvirt.py
@@ -128,6 +128,9 @@ class VObject:
         return self.oc.XMLDesc(self.lvobj)
 
     def undefine(self):
+        isPersistent = self.lvobj.isPersistent()
         self.deactivate()
-        self.vreport("undefine")
-        self.oc.undefine(self.lvobj)
+
+        if isPersistent:
+            self.vreport("undefine")
+            self.oc.undefine(self.lvobj)


### PR DESCRIPTION
I ran into an issue with transient domains when `virtpurge` is called, since a transient domain is undefined as soon as the machine is stopped you get an error like this when `virtpurge` attempts to undefine after deactivating:
```
virtpurge: error: Domain not found: no domain with matching uuid '2904419d-b283-4cfd-9f2c-7c3713ff809f' (test-q35) 
```

I've added a check before trying to undefine objects using `isPersistant`. 