### PR TITLE
Define domains last

### DIFF
--- a/modules.nix
+++ b/modules.nix
@@ -111,9 +111,9 @@ let
               in
               concatStr
                 [
-                  (scriptForType connection "domain" (getAttr "domains" opts))
                   (scriptForType connection "network" (getAttr "networks" opts))
                   (scriptForType connection "pool" (getAttr "pools" opts))
+                  (scriptForType connection "domain" (getAttr "domains" opts))
                 ];
 
             script = concatStrMap scriptForConnection (builtins.attrNames cfg.connections);


### PR DESCRIPTION
Another small one to make networks be created before domains. 

If a network doesn't exist at all a domain referencing the network will fail to be created so defining them in in this order ensures it will succeed.