### PR TITLE
Allow for the customization of the kvm section in domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Lib:
     * XML generation:
         * Allow QEMU `commandline` in domains
-        * Allow in hypervisor feature kvm section customization in domains
+        * Allow in feature section, customization of the `kvm` options, in domains
     * Domain Templates:
         * Fix defect in `storage_vol` in Windows template
         * add `virtio_drive` option for all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Lib:
     * XML generation:
         * Allow QEMU `commandline` in domains
+        * Allow in hypervisor feature kvm section customization in domains
     * Domain Templates:
         * Fix defect in `storage_vol` in Windows template
         * add `virtio_drive` option for all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
+## [Unreleased]
+* Lib:
+    * XML generation:
+        * Allow in feature section, customization of the `kvm` options, in domains
+
 ## [0.4.2]
 
 * Lib:
     * XML generation:
         * Allow QEMU `commandline` in domains
-        * Allow in feature section, customization of the `kvm` options, in domains
     * Domain Templates:
         * Fix defect in `storage_vol` in Windows template
         * add `virtio_drive` option for all

--- a/checks/checks.nix
+++ b/checks/checks.nix
@@ -34,6 +34,7 @@ in
   domain-linux = test testlib.domain domain/template-linux;
   domain-windows-1 = test testlib.domain domain/template-windows-1;
   domain-windows-2 = test testlib.domain domain/template-windows-2;
+  domain-windows-3 = test testlib.domain domain/template-windows-3;
   domain-win11 = test testlib.domain domain/win11;
 
   pool-empty = test testlib.pool pool/empty;

--- a/checks/domain/template-windows-3/expected.xml
+++ b/checks/domain/template-windows-3/expected.xml
@@ -1,0 +1,98 @@
+<domain type='kvm'>
+  <name>test-windows-3</name>
+  <uuid>a67f3ed6-fdad-462a-8c3b-d970db34d8da</uuid>
+  <memory unit='GiB'>4</memory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch='x86_64' machine='q35'>hvm</type>
+    <loader readonly='yes' type='pflash'>OVMFFull_FD_PATH/FV/OVMF_CODE.ms.fd</loader>
+    <nvram template='OVMFFull_FD_PATH/FV/OVMF_VARS.ms.fd'>/Storage/MyNVRAM.fd</nvram>
+    <boot dev='cdrom'/>
+    <boot dev='hd'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <hyperv mode='custom'>
+      <relaxed state='on'/>
+      <vapic state='on'/>
+      <spinlocks state='on' retries='8191'/>
+      <vpindex state='on'/>
+      <runtime state='on'/>
+      <synic state='on'/>
+      <stimer state='on'>
+        <direct state='on'/>
+      </stimer>
+      <reset state='on'/>
+      <vendor_id state='on' value='KVM Hv'/>
+      <frequencies state='on'/>
+      <reenlightenment state='on'/>
+      <tlbflush state='on'/>
+      <ipi state='on'/>
+    </hyperv>
+    <kvm>
+      <hidden state='on'/>
+      <hint-dedicated state='off'/>
+      <poll-control state='on'/>
+      <pv-ipi state='on'/>
+      <dirty-ring state='on' size='16384'/>
+    </kvm>
+  </features>
+  <cpu mode='host-passthrough'/>
+  <clock offset='localtime'>
+    <timer name='rtc' tickpolicy='catchup'/>
+    <timer name='pit' tickpolicy='delay'/>
+    <timer name='hpet' present='no'/>
+    <timer name='hypervclock' present='yes'/>
+  </clock>
+  <pm>
+    <suspend-to-mem enabled='no'/>
+    <suspend-to-disk enabled='no'/>
+  </pm>
+  <devices>
+    <emulator>QEMU_PATH/bin/qemu-system-x86_64</emulator>
+    <disk type='volume' device='disk'>
+      <driver name='qemu' type='qcow2' cache='none' discard='unmap'/>
+      <source pool='default' volume='win10.qcow2'/>
+      <target dev='sda' bus='sata'/>
+    </disk>
+    <disk type='file' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <source file='/Source/Win11_23H2_EnglishInternational_x64v2.iso' startupPolicy='mandatory'/>
+      <target dev='hdc' bus='sata'/>
+      <readonly/>
+    </disk>
+    <interface type='bridge'>
+      <source bridge='virbr0'/>
+    </interface>
+    <channel type='spicevmc'>
+      <target type='virtio' name='com.redhat.spice.0'/>
+    </channel>
+    <channel type='spiceport'>
+      <source channel='org.spice-space.webdav.0'/>
+      <target type='virtio' name='org.spice-space.webdav.0'/>
+    </channel>
+    <input type='tablet' bus='usb'/>
+    <input type='mouse' bus='ps2'/>
+    <input type='keyboard' bus='ps2'/>
+    <tpm model='tpm-crb'>
+      <backend type='emulator' version='2.0'/>
+    </tpm>
+    <graphics type='spice' autoport='yes'>
+      <listen type='none'/>
+      <image compression='off'/>
+      <gl enable='yes'/>
+    </graphics>
+    <sound model='ich9'/>
+    <audio id='1' type='spice'/>
+    <video>
+      <model type='virtio' heads='1' primary='yes'>
+        <acceleration accel3d='yes'/>
+      </model>
+    </video>
+    <redirdev bus='usb' type='spicevmc'/>
+    <redirdev bus='usb' type='spicevmc'/>
+    <redirdev bus='usb' type='spicevmc'/>
+    <redirdev bus='usb' type='spicevmc'/>
+  </devices>
+</domain>

--- a/checks/domain/template-windows-3/input.nix
+++ b/checks/domain/template-windows-3/input.nix
@@ -1,0 +1,24 @@
+lib: let
+  inputArgs = {
+    name = "test-windows-3";
+    uuid = "a67f3ed6-fdad-462a-8c3b-d970db34d8da";
+    storage_vol = { pool = "default"; volume = "win10.qcow2"; };
+    install_vol = /Source/Win11_23H2_EnglishInternational_x64v2.iso;
+    nvram_path = /Storage/MyNVRAM.fd;
+  };
+in lib.domain.templates.windows
+  inputArgs //
+  {
+    features = {
+      kvm = {
+        hidden.state = true;
+        hint-dedicated.state = false;
+        poll-control.state = true;
+        pv-ipi.state = true;
+        dirty-ring = {
+          state = true;
+          size = 16384;
+        };
+      };
+    } // (lib.domain.templates.windows inputArgs).features;
+  }

--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -64,6 +64,13 @@ let
                 (subelem "evmcs" [ (subattr "state" typeBoolOnOff) ] [ ])
               ])
             (subelem "vmport" [ (subattr "state" typeBoolOnOff) ] [ ])
+            (subelem "kvm" [ ] [
+              (subelem "hidden" [ (subattr "state" typeBoolOnOff) ] [ ])
+              (subelem "hint-dedicated" [ (subattr "state" typeBoolOnOff) ] [ ])
+              (subelem "poll-control" [ (subattr "state" typeBoolOnOff) ] [ ])
+              (subelem "pv-ipi" [ (subattr "state" typeBoolOnOff) ] [ ])
+              (subelem "dirty-ring" [ (subattr "state" typeBoolOnOff) (subattr "size" typeInt) ] [ ])
+            ])
           ]
         )
         (subelem "cpu"


### PR DESCRIPTION
Fixes [19](https://github.com/AshleyYakeley/NixVirt/issues/19).

Things done:

- Add kvm section in `generate-xml/domain.nix`
- Add new check, called `template-windows-3`, for verifying the newly created kvm section
- Update Changelog