### PR TITLE
Update memoryBacking section to include all modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
         * Allow in feature section, customization of the `smbios` option
         * Allow in cpu section, customization of the `feature` and `cache` option
         * Add section `sysinfo`
+        * Updated section `memoryBacking`
 
 ## [0.5.0]
 * Lib:

--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -48,13 +48,13 @@ let
         (subelem "memoryBacking" [ ]
           [
             (subelem "hugepages" [ ] [
-              (subelem "page" [ (subattr "size" typeString) (subattr "unit" typeString) (subattr "nodeset" typeString) ] [ ])
+              (subelem "page" [ (subattr "size" typeInt) (subattr "unit" typeString) (subattr "nodeset" typeString) ] [ ])
             ])
             (subelem "nosharepages" [ ] [ ])
             (subelem "locked" [ ] [ ])
             (subelem "source" [ (subattr "type" typeString) ] [ ])
             (subelem "access" [ (subattr "mode" typeString) ] [ ])
-            (subelem "allocation" [ (subattr "mode" typeString) (subattr "threads" typeString) ] [ ])
+            (subelem "allocation" [ (subattr "mode" typeString) (subattr "threads" typeInt) ] [ ])
             (subelem "discard" [ ] [ ])
           ]
         )

--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -46,8 +46,15 @@ let
         )
         (subelem "memoryBacking" [ ]
           [
+            (subelem "hugepages" [ ] [
+              (subelem "page" [ (subattr "size" typeString) (subattr "unit" typeString) (subattr "nodeset" typeString) ] [ ])
+            ])
+            (subelem "nosharepages" [ ] [ ])
+            (subelem "locked" [ ] [ ])
             (subelem "source" [ (subattr "type" typeString) ] [ ])
             (subelem "access" [ (subattr "mode" typeString) ] [ ])
+            (subelem "allocation" [ (subattr "mode" typeString) (subattr "threads" typeString) ] [ ])
+            (subelem "discard" [ ] [ ])
           ]
         )
         (subelem "features" [ ]


### PR DESCRIPTION
Updated the memoryBacking section to include all modules as specified in the [libvirt documentation](https://libvirt.org/formatdomain.html#memory-backing).

- [x] Checked rightfully translation to XML