### PR TITLE
Add iothreads section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
         * Allow in cpu section, customization of the `feature` and `cache` option
         * Add section `sysinfo`
         * add bootorder for device `disk` and `hostdev`
+        * add section `iothreads`
 
 ## [0.5.0]
 * Lib:

--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -15,6 +15,7 @@ let
         (subelem "memory" [ (subattr "unit" typeString) ] (sub "count" typeInt))
         (subelem "currentMemory" [ (subattr "unit" typeString) ] (sub "count" typeInt))
         (subelem "vcpu" [ (subattr "placement" typeString) ] (sub "count" typeInt))
+        (subelem "iothreads" [ ] (sub "count" typeInt))
 
         (subelem "sysinfo" [ (subattr "type" typeString) ] [
           (subelem "bios" [] [


### PR DESCRIPTION
Add `iothreads` section as specified in [libvirt documentation](https://libvirt.org/formatdomain.html#iothreads-allocation).