### PR TITLE
Add `ioapic` option in domain features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
         * add bootorder for device `disk` and `hostdev`
         * add section `iothreads`
         * Updated section `memoryBacking`
+        * Allow in feature section, customization of the `ioapic` option
 
 ## [0.5.0]
 * Lib:

--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -90,6 +90,7 @@ let
               (subelem "pv-ipi" [ (subattr "state" typeBoolOnOff) ] [ ])
               (subelem "dirty-ring" [ (subattr "state" typeBoolOnOff) (subattr "size" typeInt) ] [ ])
             ])
+            (subelem "ioapic" [ (subattr "driver" typeString) ] [ ])
           ]
         )
         (subelem "cpu"


### PR DESCRIPTION
Add `ioapic` option in domain features as specified in the [libvirt documentation](https://libvirt.org/formatdomain.html#hypervisor-features).