### PR TITLE
Update `clock` section to include all valid options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
         * add bootorder for device `disk` and `hostdev`
         * add section `iothreads`
         * Updated section `memoryBacking`
+        * Update section `clock`
 
 ## [0.5.0]
 * Lib:

--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -133,9 +133,22 @@ let
             (subelem "timer"
               [
                 (subattr "name" typeString)
+                (subattr "track" typeString)
                 (subattr "tickpolicy" typeString)
+                (subattr "frequency" typeInt)
+                (subattr "mode" typeString)
                 (subattr "present" typeBoolYesNo)
-              ] [ ])
+              ]
+              [
+                (subelem "catchup"
+                  [
+                    (subattr "threshold" typeInt)
+                    (subattr "slew" typeInt)
+                    (subattr "limit" typeInt)
+                  ]
+                )
+              ]
+            )
           ]
         )
         (subelem "on_poweroff" [ ] typeString)

--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -145,7 +145,7 @@ let
                     (subattr "threshold" typeInt)
                     (subattr "slew" typeInt)
                     (subattr "limit" typeInt)
-                  ]
+                  ] [ ]
                 )
               ]
             )


### PR DESCRIPTION
Update `clock` section to include all valid options as specified in the [libvirt documentation](https://libvirt.org/formatdomain.html#time-keeping).