### PR TITLE
Add more attributes to `domain.devices.memballoon`

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -386,7 +386,13 @@ let
                   (subelem "backend" [ (subattr "model" typeString) ] (sub "source" typePath))
                   addresselem
                 ])
-              (subelem "memballoon" [ (subattr "model" typeString) ] [ addresselem ])
+              (subelem "memballoon"
+                [
+                  (subattr "model" typeString)
+                  (subattr "autodeflate" typeBoolOnOff)
+                  (subattr "freePageReporting" typeBoolOnOff)
+                ]
+                [ addresselem ])
             ]
         )
         (sub "qemu-commandline" (elem "commandline"


### PR DESCRIPTION
This commit adds the attributes `autodeflate` and `freePageReporting`
into the `domain.devices.memballoon` model.

Documentation:

    https://libvirt.org/formatdomain.html#memory-balloon-device
