### PR TITLE
Add the option "forceRedefine"

### DIFF
--- a/modules.nix
+++ b/modules.nix
@@ -36,6 +36,12 @@ let
               default = false;
               description = "Enable management of libvirt objects";
             };
+          forceRedefine = lib.mkOption
+            {
+              type = bool;
+              default = true;
+              description = "Force refresh the resource even if it is running";
+            };
           verbose = lib.mkOption
             {
               type = bool;
@@ -122,7 +128,7 @@ let
                 jsonFile = packages.writeText "nixvirt module script" (builtins.toJSON opts);
                 verboseFlag = if cfg.verbose then "-v" else "";
               in
-              "${moduleHelperFile} ${verboseFlag} --connect ${connection} ${jsonFile}\n";
+              "${moduleHelperFile} ${verboseFlag} ${if cfg.forceRedefine then "--forceredefine" else ""} --connect ${connection} ${jsonFile}\n";
 
             extraPackages = [ packages.qemu-utils ] ++ (if cfg.swtpm.enable then [ packages.swtpm ] else [ ]);
             extraPaths = concatStrMap (p: "${p}/bin:") extraPackages;

--- a/tool/nixvirt-module-helper
+++ b/tool/nixvirt-module-helper
@@ -4,6 +4,7 @@ import sys, argparse, uuid, lxml.etree, json, libvirt, nixvirt
 parser = argparse.ArgumentParser(prog='nixvirt-module-helper',description='Define and control a collection of libvirt objects idempotently.')
 parser.add_argument('-v', '--verbose', action='store_true', help='report actions to stderr')
 parser.add_argument('--connect', action='store', required=True, metavar='URI', help='connection URI (e.g. qemu:///session)')
+parser.add_argument('--forceredefine', action='store_true', help='Force redefine the resource even if it is running')
 parser.add_argument('settingspath', action='store', metavar='PATH', help='path to JSON file of settings')
 args = parser.parse_args()
 
@@ -13,7 +14,7 @@ with open(args.settingspath,"r") as f:
 class TypeSpec:
     def __init__(self,session,type,itemlist):
         self.oc = nixvirt.getObjectConnection(session,type)
-        self.specList = [nixvirt.ObjectSpec.fromDefinitionFile(self.oc,item["definition"],item.get("active"),item) for item in itemlist]
+        self.specList = [nixvirt.ObjectSpec.fromDefinitionFile(self.oc,item["definition"],item.get("active"),args.forceredefine,item) for item in itemlist]
 
     def deleteOld(self):
         allObjects = self.oc.getAll()


### PR DESCRIPTION
issue: libvirt may touch the XML configuration when it think the configuration is wrong/conflict, so it's different between the xml configuration that nixvirt generated and the configuration that defined in libvirt. It will redefined every domain even the configuration is unchanged, it caused the running machine reboot when running "nixos-rebuild switch".

solution: check the settings with old setting to determine if anything changed