### PR TITLE
Fixed cpu.model

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -176,7 +176,7 @@ let
               [
                 (subattr "fallback" typeInt)
               ]
-              [ (subelem name [ ] typeString) ]
+              [ (subelem "name" [ ] typeString) ]
             )
             (subelem "topology"
               [

--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -176,7 +176,7 @@ let
               [
                 (subattr "fallback" typeString)
               ]
-              [ (subelem "name" [ ] typeString) ]
+              [ (sub "name" [ ] typeString) ]
             )
             (subelem "topology"
               [

--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -174,7 +174,7 @@ let
           [
             (subelem "model"
               [
-                (subattr "fallback" typeInt)
+                (subattr "fallback" typeString)
               ]
               [ (subelem "name" [ ] typeString) ]
             )


### PR DESCRIPTION
When setting the cpu.model field in writeXML it returned `Not Found: name` (and `expenced Int found String` for cpu.model.fallback)