### PR TITLE
Add connection option `deleteOldIfChanged` and support non-destructive reloading of `nixvirt.service`

### DIFF
--- a/tool/nixvirt-module-helper
+++ b/tool/nixvirt-module-helper
@@ -4,6 +4,7 @@ import sys, argparse, uuid, lxml.etree, json, libvirt, nixvirt
 parser = argparse.ArgumentParser(prog='nixvirt-module-helper',description='Define and control a collection of libvirt objects idempotently.')
 parser.add_argument('-v', '--verbose', action='store_true', help='report actions to stderr')
 parser.add_argument('--connect', action='store', required=True, metavar='URI', help='connection URI (e.g. qemu:///session)')
+parser.add_argument('--delete-old', action='store_true', help='destroy and recreate libvirt objects, might restart domains')
 parser.add_argument('settingspath', action='store', metavar='PATH', help='path to JSON file of settings')
 args = parser.parse_args()
 
@@ -37,7 +38,7 @@ class TypeSpec:
             objspec.setActive()
 
 try:
-    session = nixvirt.Session(args.connect,args.verbose)
+    session = nixvirt.Session(uri=args.connect, verbose=args.verbose, deactivate=args.delete_old)
 
     types = [("network","networks"),("pool","pools"),("domain","domains")]
 
@@ -49,9 +50,10 @@ try:
             typeSpecs.append(TypeSpec(session,type,itemlist))
 
     # delete old stuff
-    session.vreport("Deleting old objects")
-    for typeSpec in typeSpecs:
-        typeSpec.deleteOld()
+    if args.delete_old:
+        session.vreport("Deleting old objects")
+        for typeSpec in typeSpecs:
+            typeSpec.deleteOld()
 
     # define new stuff
     session.vreport("Defining new objects")

--- a/tool/nixvirt.py
+++ b/tool/nixvirt.py
@@ -20,9 +20,10 @@ class NixVirtError(Exception):
         return msg
 
 class Session:
-    def __init__(self,uri,verbose):
+    def __init__(self, *, uri, verbose, deactivate):
         self.conn = libvirt.open(uri)
         self.verbose = verbose
+        self.deactivate = deactivate
 
     def vreport(self,msg):
         if self.verbose:
@@ -369,7 +370,8 @@ class ObjectSpec:
                     if self.oc.session.verbose:
                         difftext = xmldiff.main.diff_trees(oldDefETree,newDefETree,formatter=xmldiff.formatting.DiffFormatter())
                         self.vreport("changed:\n" + difftext)
-                    self.subject._deactivate()
+                    if self.oc.session.deactivate:
+                        self.subject._deactivate()
                 else:
                     self.vreport("unchanged")
                 self.subject = newvobject


### PR DESCRIPTION
Right now, `nixvirt-module-helper` deletes all libvirt objects known to it and then recreates them. This results in domains getting suddenly shutdown and restarted if `nixvirt.service` changes in any way after a NixOS configuration switch.

With this PR, we now reload (rather than restart) `nixvirt.service` if the unit file changes due to `nixos-rebuild switch` and allow controlling the object deletion behavior per connection according to user preference. Default behavior (`deleteOldIfChanged = true`) is backwards compatible.

`nixvirt.service` is now marked `reloadIfChanged = true` (implying `restartIfChanged = false`) and `RemainAfterExit=yes` (in order for reloads to work). If `deleteOldIfChanged = true` for a given connection URI, both restarts and reloads will behave the same as restarts did before this change.

Currently, `deleteOldIfChanged = false` does not have any effect in Home Manager, since `nixvirt-module-helper` is run as an activation script. It will only work if NixVirt is used as a NixOS module.