### PR TITLE
Add clock.timezone to support clock.offset = "timezone"

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -200,6 +200,7 @@ let
         (subelem "clock"
           [
             (subattr "offset" typeString)
+            (subattr "timezone" typeString)
           ]
           [
             (subelem "timer"


### PR DESCRIPTION
Example:
```nix
clock = {
     offset = "timezone";
     timezone = "America/Los_Angeles";
};
```