### PR TITLE
Add xattr subattribute for virtiofs binary subelement

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -339,7 +339,7 @@ let
                       (subattr "discard" typeString)
                     ] [ ]
                   )
-                  (subelem "binary" [ (subattr "path" typePath) ] [ ])
+                  (subelem "binary" [ (subattr "path" typePath) (subattr "xattr" typeBoolOnOff) ] [ ])
                   (subelem "source" [ (subattr "dir" typePath) (subattr "name" typeString) ] [ ])
                   (subelem "target" [ (subattr "dir" typePath) ] [ ])
                   (subelem "readonly" [ ] [ ])


### PR DESCRIPTION
This allows setting xattrs, acls, etc on virtiofs filesystems, something I need for current project - thanks in advance :) (And thanks for this project in the first place - it's solved a real problem for me!)