### PR TITLE
Add blob attribute to video model element

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -453,6 +453,7 @@ let
                       (subattr "vgamem" typeInt)
                       (subattr "heads" typeInt)
                       (subattr "primary" typeBoolYesNo)
+                      (subattr "blob" typeBoolOnOff)
                     ]
                     [
                       (subelem "acceleration" [ (subattr "accel3d" typeBoolYesNo) ] [ ])


### PR DESCRIPTION
Fairly new attribute but it significantly speeds up virtio graphics for linux guests for me.  

See "Since 9.2.0" section under model [here](https://libvirt.org/formatdomain.html#video-devices) for some details.