### PR TITLE
generate-xml: domain: add serial number support

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -326,6 +326,7 @@ let
                     (subelem "readonly" [ ] [ ])
                     addresselem
                     (subelem "boot" [ (subattr "order" typeInt) ] [ ])
+                    (subelem "serial" [ ] typeString)
                   ]
                 )
               )


### PR DESCRIPTION
added support for disk serial numbers

I need it to use `/dev/disk/by-id` in VMs