### PR TITLE
add domain options required to enable pipewire backend

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -490,8 +490,32 @@ let
                   (subelem "image" [ (subattr "compression" typeBoolOnOff) ] [ ])
                   (subelem "gl" [ (subattr "enable" typeBoolYesNo) (subattr "rendernode" typeString) ] [ ])
                 ])
-              (subelem "sound" [ (subattr "model" typeString) ] [ addresselem ])
-              (subelem "audio" [ (subattr "id" typeInt) (subattr "type" typeString) ] [ ])
+              (subelem "sound" [ (subattr "model" typeString) ] 
+                [
+                  (subelem "codec" [ (subattr "type" typeString) ] [ ])
+                  (subelem "audio" [ (subattr "id" typeInt) ] [ ])
+                  addresselem 
+                ])
+              (subelem "audio" 
+                [ 
+                  (subattr "id" typeInt) 
+                  (subattr "type" typeString) 
+                  (subattr "runtimeDir" typePath)
+                ] 
+                [ 
+                  (subelem "input" 
+                    [
+                      (subattr "name" typeString) 
+                      (subattr "streamName" typeString) 
+                      (subattr "latency" typeInt) 
+                    ] [ ])
+                  (subelem "output" 
+                    [
+                      (subattr "name" typeString) 
+                      (subattr "streamName" typeString) 
+                      (subattr "latency" typeInt) 
+                    ] [ ])
+                ])
               (subelem "video" [ ]
                 [
                   (subelem "model"


### PR DESCRIPTION
add options required to enable pipewire backend

example:
```nix
sound = {
  model = "ich9";
  codec = {type = "micro";};
  audio = {id = 1;};
};
audio = {
  id = 1;
  type = "pipewire";
  runtimeDir = "/run/user/1000"; # 1000 should be the default uid. couldn't find a way to avoid hardcoding
  input = {
    name = "qemuinput";
    streamName = "qemuinput";
    latency = 16384;
  };
  output = {
    name = "qemuoutput";
    streamName = "qemuoutput";
    latency = 16384;
  };
};
```