### PR TITLE
add rom option to hostdev

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -387,6 +387,13 @@ let
                     ]
                   )
                   (subelem "boot" [ (subattr "order" typeInt) ] [ ])
+                  (subelem "rom"
+                    [
+                      (subattr "bar" typeBoolOnOff)
+                      (subattr "enabled" typeBoolYesNo) 
+                      (subattr "file" typePath)
+                    ] [ ]
+                  )
                   addresselem
                 ]
               )


### PR DESCRIPTION
I use to load patched VBIOS to the GPU, but it can also be used for other types of PCI devices.