### PR TITLE
few vcpu additions

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -14,7 +14,7 @@ let
 
         (subelem "memory" [ (subattr "unit" typeString) ] (sub "count" typeInt))
         (subelem "currentMemory" [ (subattr "unit" typeString) ] (sub "count" typeInt))
-        (subelem "vcpu" [ (subattr "placement" typeString) (subattr "cpuset" typeString) ] (sub "count" typeInt))
+        (subelem "vcpu" [ (subattr "placement" typeString) (subattr "cpuset" typeString) (subattr "current" typeInt) ] (sub "count" typeInt))
         (subelem "iothreads" [ ] (sub "count" typeInt))
         (subelem "cputune" [ ] [
           (subelem "vcpupin" [ (subattr "vcpu" typeInt) (subattr "cpuset" typeString) ] [ ])

--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -15,6 +15,9 @@ let
         (subelem "memory" [ (subattr "unit" typeString) ] (sub "count" typeInt))
         (subelem "currentMemory" [ (subattr "unit" typeString) ] (sub "count" typeInt))
         (subelem "vcpu" [ (subattr "placement" typeString) (subattr "cpuset" typeString) (subattr "current" typeInt) ] (sub "count" typeInt))
+        (subelem "vcpus" [ ] [
+          (subelem "vcpu" [ (subattr "id" typeInt) (subattr "enabled" typeBoolYesNo) (subattr "hotpluggable" typeBoolYesNo) (subattr "order" typeInt) ] [ ])
+        ])
         (subelem "iothreads" [ ] (sub "count" typeInt))
         (subelem "cputune" [ ] [
           (subelem "vcpupin" [ (subattr "vcpu" typeInt) (subattr "cpuset" typeString) ] [ ])


### PR DESCRIPTION
- Add the "current" attribute to vcpu
-  Add the "vcpus" element.

Since the usage isn't very clear on https://libvirt.org/formatdomain.html, here is an example use case: https://docs.darwinkvm.com/writeups/01-FakeCoreCount/02-XML/.