### PR TITLE
Replace hm activation script with oneshot service

### DIFF
--- a/modules.nix
+++ b/modules.nix
@@ -154,6 +154,7 @@ let
                 Service = {
                   ExecStart = packages.writeShellScript "nixvirt-start" script;
                   Type = "oneshot";
+                  RestartIfChanged = true;
                 };
                 Install = {
                   WantedBy = ["default.target"];

--- a/modules.nix
+++ b/modules.nix
@@ -144,6 +144,7 @@ let
           then
             {
               home.packages = extraPackages;
+              home.activation.NixVirt = lib.hm.dag.entryAfter [ "installPackages" ] script;
               systemd.user.services.nixvirt = {
                 Unit = {
                   Description = "Configure libvirt objects";
@@ -155,7 +156,7 @@ let
                   Type = "oneshot";
                 };
                 Install = {
-                  WantedBy = "default.target";
+                  WantedBy = ["default.target"];
                 };
               }; 
             }

--- a/modules.nix
+++ b/modules.nix
@@ -144,7 +144,6 @@ let
           then
             {
               home.packages = extraPackages;
-              home.activation.NixVirt = lib.hm.dag.entryAfter [ "installPackages" ] script;
               systemd.user.services.nixvirt = {
                 Unit = {
                   Description = "Configure libvirt objects";

--- a/modules.nix
+++ b/modules.nix
@@ -148,8 +148,9 @@ let
               systemd.user.services.nixvirt = {
                 Unit = {
                   Description = "Configure libvirt objects";
-                  Requires = "libvirtd.service";
-                  After = "libvirtd.service";
+                  # Its missing the wantedBy etc but it should be fine 
+                  # since those other services _should_ start before the 
+                  # any of the user services start running,
                 };
                 Service = {
                   ExecStart = packages.writeShellScript "nixvirt-start" script;

--- a/modules.nix
+++ b/modules.nix
@@ -144,7 +144,20 @@ let
           then
             {
               home.packages = extraPackages;
-              home.activation.NixVirt = lib.hm.dag.entryAfter [ "installPackages" ] script;
+              systemd.user.services.nixvirt = {
+                Unit = {
+                  Description = "Configure libvirt objects";
+                  Requires = "libvirtd.service";
+                  After = "libvirtd.service";
+                };
+                Service = {
+                  ExecStart = packages.writeShellScript "nixvirt-start" script;
+                  Type = "oneshot";
+                };
+                Install = {
+                  WantedBy = "default.target";
+                };
+              }; 
             }
           else
             {


### PR DESCRIPTION
Currently by using the hm activation script to run the "install" scrip. It will crash the entire rest of that activation script if the install script where to crash (which it like to do if eg the pool storage path is missing). 

Ive tested it locally and it seams to work with my config. but you might want to take a look. Since its not fully equivalent to the old activation script.