### PR TITLE
Add os.loader stateless flag

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -59,7 +59,7 @@ let
         (subelem "os" [ ]
           [
             (elem "type" [ (subattr "arch" typeString) (subattr "machine" typeString) ] (sub "type" typeString))
-            (subelem "loader" [ (subattr "readonly" typeBoolYesNo) (subattr "type" typeString) ] (sub "path" typePath))
+            (subelem "loader" [ (subattr "readonly" typeBoolYesNo) (subattr "stateless" typeBoolYesNo) (subattr "type" typeString) ] (sub "path" typePath))
             (subelem "nvram"
               [
                 (subattr "template" typePath)


### PR DESCRIPTION
Currently it is impossible to run VMs without an associated NVRAM file. This flag tells libvirt to run the loader without any NVRAM, discarding loader configuration at shutdown.