### PR TITLE
feat: add nvram templateFormat

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -63,6 +63,7 @@ let
             (subelem "nvram"
               [
                 (subattr "template" typePath)
+                (subattr "templateFormat" typeString)
                 (subattr "type" typeString)
                 (subattr "format" typeString)
               ]


### PR DESCRIPTION
> If needed, the template attribute can be used to override the automatically chosen NVRAM template and templateFormat to specify the format for the template file (currently supported are raw and qcow2)

https://libvirt.org/formatdomain.html
for some reason it has been literally unusable for me without this option