### PR TITLE
Added support for `baseBoard`  and `chassis` in domains

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -55,6 +55,12 @@ let
           (subelem "system" [ ] [
             (subelem "entry" [ (subattr "name" typeString) ] (sub "value" typeString))
           ])
+          (subelem "baseBoard" [ ] [
+            (subelem "entry" [ (subattr "name" typeString) ] (sub "value" typeString))
+          ])
+          (subelem "chassis" [ ] [
+            (subelem "entry" [ (subattr "name" typeString) ] (sub "value" typeString))
+          ])
         ])
 
         (subelem "os" [ (subattr "firmware" typeString) ]


### PR DESCRIPTION
Hey @AshleyYakeley 

I hope that you will add the 2 options `baseBoard and `chassis`.

They are documented under [SMBIOS System Information](https://libvirt.org/formatdomain.html#smbios-system-information)