### PR TITLE
Add `serverName` subattr under `<audio>`

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -514,6 +514,7 @@ let
                   (subattr "id" typeInt)
                   (subattr "type" typeString)
                   (subattr "runtimeDir" typePath)
+                  (subattr "serverName" typeString)
                 ]
                 [
                   (subelem "input"


### PR DESCRIPTION
## Description

This adds support for PulseAudio as written by the [domain format](https://libvirt.org/formatdomain.html#pulseaudio-audio-backend).

## Possible alternatives

There are many unsupported audio backends. A solution could be to implement some sort of tagged union, based upon the `id` field for `<audio>`. At the moment, there are no checks and you could mix-match different properties which would be invalid.
