### PR TITLE
Add XML elements for System Management Mode and secure boot hint flag

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -60,7 +60,7 @@ let
         (subelem "os" [ (subattr "firmware" typeString) ]
           [
             (elem "type" [ (subattr "arch" typeString) (subattr "machine" typeString) ] (sub "type" typeString))
-            (subelem "loader" [ (subattr "readonly" typeBoolYesNo) (subattr "stateless" typeBoolYesNo) (subattr "type" typeString) ] (sub "path" typePath))
+            (subelem "loader" [ (subattr "readonly" typeBoolYesNo) (subattr "stateless" typeBoolYesNo) (subattr "secure" typeBoolYesNo) (subattr "type" typeString) ] (sub "path" typePath))
             (subelem "nvram"
               [
                 (subattr "template" typePath)

--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -171,6 +171,9 @@ let
               (subelem "dirty-ring" [ (subattr "state" typeBoolOnOff) (subattr "size" typeInt) ] [ ])
             ])
             (subelem "ioapic" [ (subattr "driver" typeString) ] [ ])
+            (subelem "smm" [ (subattr "state" typeBoolOnOff) ] [
+              (subelem "tseg" [ (subattr "unit" typeString) ] (sub "count" typeInt))
+            ])
           ]
         )
         (subelem "cpu"


### PR DESCRIPTION
This enables the following features:

```xml
<domain>
  <os>
    <loader secure='yes' ...>/path/to/ovmf/OVMF_CODE.fd</loader>
  </os>
  <features>
    <smm state='on'>
      <tseg unit='MiB'>8</tseg>
    </smm>
  </features>
</domain>
```