### PR TITLE
Support setting VLAN tag in domain XML

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -461,6 +461,17 @@ let
                     addresselem
                     (subelem "reconnect" [ (subattr "enabled" typeBoolYesNo) (subattr "timeout" typeInt) ] [ ])
                   ])
+                  (subelem "vlan"
+                    [
+                      (subattr "trunk" typeBoolYesNo)
+                    ]
+                    [
+                      (subelem "tag"
+                        [
+                          (subattr "id" typeInt)
+                          (subattr "nativeMode" typeString)
+                        ] [ ])
+                    ])
                   (subelem "model" [ (subattr "type" typeString) ] [ ])
                   targetelem
                   addresselem


### PR DESCRIPTION
Works the same way it does in network XML, so copy the definition from there.

This simplifies host network configuration when running multiple VMs in different VLANs (a single VLAN-aware bridge interface and trunk port suffices, with guest VLAN configuration done entirely within libvirt).