### PR TITLE
feat: add startupPolicy to hostdev

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -384,7 +384,10 @@ let
                 ]
                 [
                   (subelem "driver" [ (subattr "name" typeString) (subattr "model" typeString) ] [ ])
-                  (subelem "source" [ ]
+                  (subelem "source"
+                    [
+                      (subattr "startupPolicy" typeString)
+                    ]
                     [
                       (subelem "vendor" [ (subattr "id" typeInt) ] [ ])
                       (subelem "product" [ (subattr "id" typeInt) ] [ ])


### PR DESCRIPTION
Hello!
Thank you for this amazing project

That PR is a little contribution to add a *startupPolicy* field from _hostdev_ as specified by [USB / PCI / SCSI devices](https://libvirt.org/formatdomain.html#usb-pci-scsi-devices)

Best see