### PR TITLE
Add target option for ethernet interface

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -461,6 +461,12 @@ let
                     addresselem
                     (subelem "reconnect" [ (subattr "enabled" typeBoolYesNo) (subattr "timeout" typeInt) ] [ ])
                   ])
+                  (subelem "target"
+                    [
+                      (subattr "dev" typeString)
+                      (subattr "managed" typeBoolYesNo)
+                    ] [ ]
+                  )
                   (subelem "model" [ (subattr "type" typeString) ] [ ])
                   targetelem
                   addresselem


### PR DESCRIPTION
Add target element for  interface type ethernet. This is useful when setting up manual tap devices. 

See https://libvirt.org/formatdomain.html#generic-ethernet-connection 