### PR TITLE
Enable joliet for virtio-win.iso

### DIFF
--- a/guest-install.nix
+++ b/guest-install.nix
@@ -1,5 +1,5 @@
 packages:
 {
   virtio-win.iso =
-    packages.runCommand "virtio-win.iso" { } "${packages.cdrtools}/bin/mkisofs -l -V VIRTIO-WIN -o $out ${packages.virtio-win}";
+    packages.runCommand "virtio-win.iso" { } "${packages.cdrtools}/bin/mkisofs -J -V VIRTIO-WIN -o $out ${packages.virtio-win}";
 }


### PR DESCRIPTION
without joliet, hyphens in filenames turn into underscores. automation scripts like [this](https://schneegans.de/windows/unattend-generator) doesn't expect that.