### PR TITLE
feat(domain): add missing attributes to <graphics> element

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -520,6 +520,11 @@ let
                 [
                   (subattr "type" typeString)
                   (subattr "autoport" typeBoolYesNo)
+                  (subattr "port" typeInt)
+                  (subattr "tlsPort" typeInt)
+                  (subattr "passwd" typeString)
+                  (subattr "websocket" typeInt)
+                  (subattr "sharePolicy" typeString)
                 ]
                 [
                   (subelem "listen" [ (subattr "type" typeString) (subattr "address" typeString) ] [ ])


### PR DESCRIPTION
This PR adds several missing attributes to the domain <graphics> element, aligning NixVirt's definition more closely with the upstream libvirt API documentation.

Previously, users were unable to statically define display ports, set passwords, or configure websocket and share policies because the XML builder lacked the schema vocabulary to pass them through.

Changes:
Added the following subattr definitions to the graphics block:
port (typeInt)
tlsPort (typeInt)
passwd (typeString)
websocket (typeInt)
sharePolicy (typeString)

References:
[libvirt domain XML format - Graphical framebuffers](https://libvirt.org/formatdomain.html#graphical-framebuffers)