### PR TITLE
Support dnsmasq passthrough options

### DIFF
--- a/checks/checks.nix
+++ b/checks/checks.nix
@@ -26,6 +26,7 @@ in
 {
   network-empty = test testlib.network network/empty;
   network-bridge = test testlib.network network/bridge;
+  network-dnsmasq-options = test testlib.network network/dnsmasq-options;
 
   domain-empty = test testlib.domain domain/empty;
   domain-linux-1 = test testlib.domain domain/template-linux-1;

--- a/checks/network/dnsmasq-options/expected.xml
+++ b/checks/network/dnsmasq-options/expected.xml
@@ -1,0 +1,19 @@
+<network xmlns:dnsmasq='http://libvirt.org/schemas/network/dnsmasq/1.0'>
+  <name>test-dnsmasq-options</name>
+  <uuid>7f3caa98-cf49-4a7a-8796-a950723571a4</uuid>
+  <bridge name='virbr1'/>
+  <forward mode='nat'>
+    <nat>
+      <port start='1024' end='65535'/>
+    </nat>
+  </forward>
+  <dns enable='no'/>
+  <ip address='192.168.1.0' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.1.2' end='192.168.1.254'/>
+    </dhcp>
+  </ip>
+  <dnsmasq:options>
+    <dnsmasq:option value='dhcp-option=6,9.9.9.10'/>
+  </dnsmasq:options>
+</network>

--- a/checks/network/dnsmasq-options/input.nix
+++ b/checks/network/dnsmasq-options/input.nix
@@ -1,0 +1,35 @@
+_: {
+  name = "test-dnsmasq-options";
+  uuid = "7f3caa98-cf49-4a7a-8796-a950723571a4";
+  forward = {
+    mode = "nat";
+    nat = {
+      port = {
+        start = 1024;
+        end = 65535;
+      };
+    };
+  };
+  bridge = {
+    name = "virbr1";
+  };
+  ip = {
+    address = "192.168.1.0";
+    netmask = "255.255.255.0";
+    dhcp = {
+      range = {
+        start = "192.168.1.2";
+        end = "192.168.1.254";
+      };
+    };
+  };
+  dns = {
+    enable = false;
+  };
+  "xmlns:dnsmasq" = "http://libvirt.org/schemas/network/dnsmasq/1.0";
+  "dnsmasq:options" = {
+    "dnsmasq:option" = [
+      { value = "dhcp-option=6,9.9.9.10"; }
+    ];
+  };
+}

--- a/generate-xml/network.nix
+++ b/generate-xml/network.nix
@@ -5,7 +5,12 @@ let
 
   # https://libvirt.org/formatnetwork.html
   process = with generate;
-    elem "network" [ (subattr "ipv6" typeBoolYesNo) (subattr "trustGuestRxFilters" typeBoolYesNo) ]
+    elem "network"
+      [
+        (subattr "ipv6" typeBoolYesNo)
+        (subattr "trustGuestRxFilters" typeBoolYesNo)
+        (subattr "xmlns:dnsmasq" typeString)
+      ]
       [
         (subelem "name" [ ] typeString)
         (subelem "uuid" [ ] typeString)
@@ -195,6 +200,9 @@ let
                   ] [ ])
               ])
           ])
+        (subelem "dnsmasq:options" [ ] [
+          (subelem "dnsmasq:option" [ (subattr "value" typeString) ] [ ])
+        ])
       ];
 
 in


### PR DESCRIPTION
libvirt can pass options to the underlying dnsmasq as described in the [docs](https://libvirt.org/formatnetwork.html#network-namespaces) and [schema](https://github.com/libvirt/libvirt/blob/2e25854933d99dc09a2ff03d1b5edf2d665a2c50/src/conf/schemas/network.rng#L447). This PR adds support for generating those options to nixvirt.