### PR TITLE
feat: add separate microvm template

### DIFF
--- a/checks/checks.nix
+++ b/checks/checks.nix
@@ -30,6 +30,7 @@ in
   domain-empty = test testlib.domain domain/empty;
   domain-linux-1 = test testlib.domain domain/template-linux-1;
   domain-linux-2 = test testlib.domain domain/template-linux-2;
+  domain-linux-microvm-1 = test testlib.domain domain/template-linux-microvm-1;
   domain-lxc = test testlib.domain domain/template-lxc;
   domain-windows-1 = test testlib.domain domain/template-windows-1;
   domain-windows-2 = test testlib.domain domain/template-windows-2;

--- a/checks/domain/template-linux-microvm-1/expected.xml
+++ b/checks/domain/template-linux-microvm-1/expected.xml
@@ -1,0 +1,48 @@
+<domain type='kvm'>
+  <name>test-microvm</name>
+  <uuid>3a7b5c1d-e2f4-4a6b-8c0d-1e2f3a4b5c6d</uuid>
+  <memory unit='GiB'>2</memory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch='x86_64' machine='microvm'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+  </features>
+  <cpu mode='host-passthrough'/>
+  <clock offset='utc'>
+    <timer name='rtc' tickpolicy='catchup'/>
+    <timer name='pit' tickpolicy='delay'/>
+    <timer name='hpet' present='no'/>
+  </clock>
+  <devices>
+    <emulator>QEMU_PATH/bin/qemu-system-x86_64</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2' cache='none' discard='unmap'/>
+      <source file='/Storage/MyHD.qcow2'/>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='raw'/>
+      <source file='/Storage/cloud-init.img'/>
+      <target dev='vdb' bus='virtio'/>
+      <readonly/>
+    </disk>
+    <interface type='bridge'>
+      <source bridge='virbr0'/>
+      <model type='virtio'/>
+    </interface>
+    <serial type='pty'/>
+    <console type='pty'>
+      <target type='virtio'/>
+    </console>
+    <channel type='unix'>
+      <target type='virtio' name='org.qemu.guest_agent.0'/>
+    </channel>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+    </rng>
+  </devices>
+</domain>

--- a/checks/domain/template-linux-microvm-1/input.nix
+++ b/checks/domain/template-linux-microvm-1/input.nix
@@ -1,0 +1,7 @@
+lib: lib.domain.templates.linux-microvm
+{
+  name = "test-microvm";
+  uuid = "3a7b5c1d-e2f4-4a6b-8c0d-1e2f3a4b5c6d";
+  storage_vol = /Storage/MyHD.qcow2;
+  cloud_init_vol = /Storage/cloud-init.img;
+}

--- a/templates/domain.nix
+++ b/templates/domain.nix
@@ -5,5 +5,6 @@ in
 base //
 {
   linux = import domain/linux.nix stuff;
+  linux-microvm = import domain/linux-microvm.nix stuff;
   windows = import domain/windows.nix stuff;
 }

--- a/templates/domain/linux-microvm.nix
+++ b/templates/domain/linux-microvm.nix
@@ -1,0 +1,90 @@
+stuff@{ packages, ... }:
+{ name
+, uuid
+, vcpu ? { count = 2; }
+, memory ? { count = 2; unit = "GiB"; }
+, storage_vol ? null
+, backing_vol ? null
+, cloud_init_vol ? null
+, bridge_name ? "virbr0"
+, net_iface_mac ? null
+, ...
+}:
+let
+  base = import ./base.nix stuff;
+  inherit (base) mkstorage;
+  mksourcetype = src:
+    if builtins.isAttrs src && src ? "volume" then "volume" else "file";
+  mksource = src:
+    if builtins.isString src || builtins.isPath src then { file = src; } else src;
+in
+{
+  type = "kvm";
+  inherit name uuid vcpu memory;
+
+  os =
+    {
+      type = "hvm";
+      arch = "x86_64";
+      machine = "microvm";
+      boot = [{ dev = "hd"; }];
+    };
+  features =
+    {
+      acpi = { };
+      apic = { };
+    };
+  cpu = { mode = "host-passthrough"; };
+  clock =
+    {
+      offset = "utc";
+      timer =
+        [
+          { name = "rtc"; tickpolicy = "catchup"; }
+          { name = "pit"; tickpolicy = "delay"; }
+          { name = "hpet"; present = false; }
+        ];
+    };
+  devices =
+    {
+      emulator = "${packages.qemu}/bin/qemu-system-x86_64";
+      disk =
+        (if builtins.isNull storage_vol then [ ] else [ (mkstorage true storage_vol backing_vol) ]) ++
+        (if builtins.isNull cloud_init_vol then [ ] else
+          [
+            {
+              type = mksourcetype cloud_init_vol;
+              device = "disk";
+              driver =
+                {
+                  name = "qemu";
+                  type = "raw";
+                };
+              source = mksource cloud_init_vol;
+              target = { dev = "vdb"; bus = "virtio"; };
+              readonly = true;
+            }
+          ]);
+      interface =
+        {
+          type = "bridge";
+          model = { type = "virtio"; };
+          mac = if builtins.isNull net_iface_mac then null else { address = net_iface_mac; };
+          source = { bridge = bridge_name; };
+        };
+      channel =
+        [
+          {
+            type = "unix";
+            target = { type = "virtio"; name = "org.qemu.guest_agent.0"; };
+          }
+        ];
+      serial = { type = "pty"; };
+      console = { type = "pty"; target = { type = "virtio"; }; };
+      rng =
+        {
+          model = "virtio";
+          backend = { model = "random"; source = /dev/urandom; };
+        };
+    };
+}


### PR DESCRIPTION
This pull request adds support for a new Linux MicroVM domain template, enabling configuration and testing of microVM-based virtual machines. The changes introduce a new template, corresponding test cases, and update the relevant Nix expressions to integrate the MicroVM template with the existing domain infrastructure.

**New Linux MicroVM Domain Template:**

* Added a new template for Linux MicroVM domains in `templates/domain/linux-microvm.nix`, supporting configuration for memory, vCPUs, storage, cloud-init, networking, and device options.
* Integrated the new `linux-microvm` template into the domain templates list in `templates/domain.nix`.

**Testing and Validation:**

* Added a new test case entry for the MicroVM template in `checks/checks.nix`, enabling automated testing.
* Created input and expected output files for the MicroVM domain test in `checks/domain/template-linux-microvm-1/input.nix` and `checks/domain/template-linux-microvm-1/expected.xml`, validating correct template rendering. [[1]](diffhunk://#diff-21606e05fa25d09307cc2a6afdb188c91718cd50468e9fe4eb8e12fb8d1759d3R1-R7) [[2]](diffhunk://#diff-0889b54b3a209393d82eb810d81e23741e52f7d138dacc04bb72915c7a6a14d4R1-R48)