### PR TITLE
feat(domain): add maxphysaddr, disk/controller iothread, and hub support

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -351,6 +351,8 @@ let
                         (subattr "cache" typeString)
                         (subattr "io" typeString)
                         (subattr "discard" typeString)
+                        (subattr "queues" typeInt)
+                        (subattr "iothread" typeInt)
                       ] [ ]
                     )
                   ] ++

--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -593,6 +593,7 @@ let
                   addresselem
                 ])
               (subelem "redirdev" [ (subattr "bus" typeString) (subattr "type" typeString) ] [ addresselem ])
+              (subelem "hub" [ (subattr "type" typeString) ] [ addresselem ])
               (subelem "watchdog" [ (subattr "model" typeString) (subattr "action" typeString) ] [ ])
               (subelem "rng" [ (subattr "model" typeString) ]
                 [

--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -391,6 +391,7 @@ let
                   (subattr "ports" typeInt)
                 ]
                 [
+                  (subelem "driver" [ (subattr "queues" typeInt) (subattr "iothread" typeInt) ] [ ])
                   (subelem "master" [ (subattr "startport" typeInt) ] [ ])
                   targetelem
                   addresselem

--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -209,6 +209,14 @@ let
               (subattr "level" typeInt)
               (subattr "mode" typeString)
             ] [ ])
+            (subelem "maxphysaddr"
+              [
+                (subattr "mode" typeString)
+                (subattr "bits" typeInt)
+                (subattr "limit" typeInt)
+              ]
+              [ ]
+            )
             (subelem "feature" [
               (subattr "policy" typeString)
               (subattr "name" typeString)


### PR DESCRIPTION
Thanks for the amazing project! This adds a few missing elements that I
stumbled upon while migrating my libvirt VMs over.

- Added `<maxphysaddr>` to `<cpu>` (`mode`, `bits`, `limit`).
- Added `queues` and `iothread` attributes to the disk `<driver>`.
- Added `<driver>` to `<controller>` (`queues`, `iothread`) for  virtio-scsi IOThread support.
- Added `<hub>` to `<devices>` (`type` + address).

Refs:
  - [CPU model and topology](https://libvirt.org/formatdomain.html#cpu-model-and-topology)
  - [Hard drives, floppy disks, CDROMs](https://libvirt.org/formatdomain.html#hard-drives-floppy-disks-cdroms)
  - [Controllers](https://libvirt.org/formatdomain.html#controllers)
  - [Hub devices](https://libvirt.org/formatdomain.html#hub-devices)