### PR TITLE
feat(domain): add memtune options

### DIFF
--- a/generate-xml/domain.nix
+++ b/generate-xml/domain.nix
@@ -14,6 +14,12 @@ let
         (subelemraw "metadata" [ ])
 
         (subelem "memory" [ (subattr "unit" typeString) ] (sub "count" typeInt))
+        (subelem "memtune" [ ] [
+          (subelem "hard_limit" [ (subattr "unit" typeString) ] (sub "count" typeInt))
+          (subelem "soft_limit" [ (subattr "unit" typeString) ] (sub "count" typeInt))
+          (subelem "swap_hard_limit" [ (subattr "unit" typeString) ] (sub "count" typeInt))
+          (subelem "min_guarantee" [ (subattr "unit" typeString) ] (sub "count" typeInt))
+        ])
         (subelem "currentMemory" [ (subattr "unit" typeString) ] (sub "count" typeInt))
         (subelem "vcpu" [ (subattr "placement" typeString) (subattr "cpuset" typeString) (subattr "current" typeInt) ] (sub "count" typeInt))
         (subelem "vcpus" [ ] [


### PR DESCRIPTION
example usage:
```
      memtune = {
        hard_limit = {
          unit = "GiB";
          count = 9;
        };
        soft_limit = {
          unit = "MiB";
          # 8.5GiB
          count = 8704;
        };
      };
      memory = {
        count = 8;
        unit = "GiB";
      };
```