### PR TITLE
Fixed bug where MAC address is not auto assigned

### DIFF
--- a/tool/nixvirt.py
+++ b/tool/nixvirt.py
@@ -183,7 +183,8 @@ class NetworkConnection(ObjectConnection):
     def _fixDefinitionETree(self,objid,specDefETree):
         addresses = specDefETree.xpath("/network/mac/@address")
         if len(addresses) == 0:
-            fwdMode = specDefETree.xpath("/network/forward/@mode")
+            fwdModes = specDefETree.xpath("/network/forward/@mode")
+            fwdMode = fwdModes[0] if len(fwdModes) >= 1 else None
             if fwdMode in [None, 'route', 'nat']:
                 addr = self._assignMacAddress(objid,0)
                 mac = lxml.etree.Element("mac")


### PR DESCRIPTION
```python
fwdMode = specDefETree.xpath("/network/forward/@mode")
if fwdMode in [None, 'route', 'nat']:
```

The `xpath` function returns a list of results, however the `if` statement assumes that it is a single result. Because of this, the `if` statement does not trigger as intended, preventing MAC address assignment. On my machine, this results in unnecessary restarts because the MAC address constantly changes after each rebuild. 

This fix simply takes the first result from `xpath` (I am not familiar with the codebase enough to know if there is a better way of doing it)